### PR TITLE
[chore] add text-img emb similarity function

### DIFF
--- a/sequential/src/utils.py
+++ b/sequential/src/utils.py
@@ -1,12 +1,13 @@
 import json
 import os
+import pickle
 import random
 from datetime import datetime
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 import yaml
-import pickle
 
 
 def seed_everything(seed: int = 42):
@@ -31,6 +32,7 @@ def load_json(path):
     with open(path, "r") as file:
         data = json.load(file)
     return data
+
 
 def load_pkl(path):
     with open(path, "rb") as file:
@@ -78,3 +80,8 @@ def simple_ndcg_at_k_batch(k, rank):
 def mk_dir(file_path):
     if not os.path.exists(file_path):
         os.makedirs(file_path)
+
+
+def get_sim_img(text, imgs):
+    # text : 512, imgs: n * 512
+    return imgs[F.cosine_similarity(text, imgs, dim=1).argmax()].unsqueeze(0)  # 1 * 512


### PR DESCRIPTION
### 코멘트
- 현재 text <-> gen img 사이의 유사도를 구해야 함. fiass를 사용하려 했으나 구조상 적합하지 않다고 판단됨.
- 비교를 위해 돌려보는 모델이라 많이 돌려보지 않을 것 같다고 생각되어, 약간 느려도 감수하고 torch에 구현된 것을 사용하는 것이 나을 것 같음.